### PR TITLE
Add connected wallet event

### DIFF
--- a/html-dev/index.html
+++ b/html-dev/index.html
@@ -56,6 +56,9 @@
         disconnectButtonClass: "disconnectButton",
         connectedButtonClass: "connectedButton"
       });
+      document.querySelector("#acs").addEventListener("connected", (event) => {
+        console.log("Connected to the wallet with address: " + event.detail.address);
+      });
     </script>
   </body>
 </html>

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -1,17 +1,20 @@
 import { h, createContext, ComponentChildren } from "preact";
-import { AppConfigurations } from "./models";
+import { Configurations } from "./models";
 
-export const ConfigContext = createContext<AppConfigurations>(
-  {} as AppConfigurations
+export const ConfigContext = createContext<Configurations>(
+  {} as Configurations
 );
 
 interface Props {
   children: ComponentChildren;
-  config: AppConfigurations;
+  config: Configurations;
   element?: HTMLElement;
 }
-export const AppContext = ({ children, config }: Props) => {
+export const AppContext = ({ children, config, element }: Props) => {
+  const enhancedConfig = { ...config, element };
   return (
-    <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
+    <ConfigContext.Provider value={enhancedConfig}>
+      {children}
+    </ConfigContext.Provider>
   );
 };

--- a/src/layout/Main.tsx
+++ b/src/layout/Main.tsx
@@ -1,5 +1,5 @@
-import tw from 'twin.macro';
-import { h } from 'preact';
+import tw from "twin.macro";
+import { h } from "preact";
 import {
   useCallback,
   useContext,
@@ -7,17 +7,17 @@ import {
   useMemo,
   useRef,
   useState,
-} from 'preact/hooks';
-import { Router, RouteComponent } from '../layout/Router';
-import { Actions } from '../routes/Actions';
-import { Stake } from '../routes/Stake';
-import { Unstake } from '../routes/Unstake';
-import { Claim } from '../routes/Claim';
-import { Button } from '../components/wallet-adapter/ui/Button';
-import { WalletConnectButton } from '../components/wallet-adapter/ui/WalletConnectButton';
-import { WalletModalButton } from '../components/wallet-adapter/ui/WalletModalButton';
-import { useWallet } from '../components/wallet-adapter/useWallet';
-import { ConfigContext } from '../AppContext';
+} from "preact/hooks";
+import { Router, RouteComponent } from "../layout/Router";
+import { Actions } from "../routes/Actions";
+import { Stake } from "../routes/Stake";
+import { Unstake } from "../routes/Unstake";
+import { Claim } from "../routes/Claim";
+import { Button } from "../components/wallet-adapter/ui/Button";
+import { WalletConnectButton } from "../components/wallet-adapter/ui/WalletConnectButton";
+import { WalletModalButton } from "../components/wallet-adapter/ui/WalletModalButton";
+import { useWallet } from "../components/wallet-adapter/useWallet";
+import { ConfigContext } from "../AppContext";
 
 const styles = {
   wallet_adapter_dropdown_wrapper: tw`relative inline-block text-left font-sans`,
@@ -28,10 +28,10 @@ const styles = {
 };
 
 const Main = () => {
-  const { publicKey, wallet } = useWallet();
+  const { publicKey, wallet, connected } = useWallet();
   const [active, setActive] = useState(false);
   const ref = useRef<HTMLUListElement>(null);
-  const { disconnectButtonClass, connectedButtonClass } =
+  const { disconnectButtonClass, connectedButtonClass, element } =
     useContext(ConfigContext);
 
   const base58 = useMemo(() => publicKey?.toBase58(), [publicKey]);
@@ -39,7 +39,7 @@ const Main = () => {
     if (!wallet || !base58) {
       return null;
     }
-    return base58.slice(0, 4) + '..' + base58.slice(-4);
+    return `${base58.slice(0, 4)}..${base58.slice(-4)}`;
   }, [wallet, base58]);
 
   const toggleDropdown = useCallback(() => {
@@ -49,6 +49,20 @@ const Main = () => {
   const closeDropdown = useCallback(() => {
     setActive(false);
   }, []);
+
+  useEffect(() => {
+    if (connected && element) {
+      const connectedEvent = new CustomEvent("connected", {
+        detail: {
+          address: base58,
+        },
+        bubbles: true,
+        cancelable: true,
+        composed: false, // if you want to listen on parent turn this on
+      });
+      element.dispatchEvent(connectedEvent);
+    }
+  }, [connected, element]);
 
   useEffect(() => {
     const listener = (event: MouseEvent | TouchEvent) => {
@@ -62,12 +76,12 @@ const Main = () => {
       closeDropdown();
     };
 
-    document.addEventListener('mousedown', listener);
-    document.addEventListener('touchstart', listener);
+    document.addEventListener("mousedown", listener);
+    document.addEventListener("touchstart", listener);
 
     return () => {
-      document.removeEventListener('mousedown', listener);
-      document.removeEventListener('touchstart', listener);
+      document.removeEventListener("mousedown", listener);
+      document.removeEventListener("touchstart", listener);
     };
   }, [ref, closeDropdown]);
 
@@ -95,7 +109,7 @@ const Main = () => {
           styles.wallet_adapter_button_trigger_active,
         ]}
         externalButtonClass={connectedButtonClass}
-        style={{ pointerEvents: active ? 'none' : 'auto' }}
+        style={{ pointerEvents: active ? "none" : "auto" }}
         onClick={toggleDropdown}
       >
         {content}
@@ -109,10 +123,10 @@ const Main = () => {
       >
         <Router
           routes={{
-            '/': <RouteComponent component={Actions} />,
-            '/stake': <RouteComponent component={Stake} />,
-            '/unstake': <RouteComponent component={Unstake} />,
-            '/claim': <RouteComponent component={Claim} />,
+            "/": <RouteComponent component={Actions} />,
+            "/stake": <RouteComponent component={Stake} />,
+            "/unstake": <RouteComponent component={Unstake} />,
+            "/claim": <RouteComponent component={Claim} />,
           }}
         />
       </div>


### PR DESCRIPTION
Whenever the wallet is connected, we'll dispatch the event on the element specified in the init script.

To catch the event, do this:
```javascript
document.querySelector("#acs").addEventListener("connected", (event) => {
  console.log("Connected to the wallet with address: " + event.detail.address);
});
```